### PR TITLE
Make Init DB Script Executable

### DIFF
--- a/codex-processes-ap2-docker-test-setup/db/init-db.sh
+++ b/codex-processes-ap2-docker-test-setup/db/init-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL


### PR DESCRIPTION
Sets executable file flags on the init-db.sh.
Also adjusts the shebang line.

Fixes #41 